### PR TITLE
Adding support for multi arch builds (amd64 + arm64)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,8 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=ghcr.io/jacobweinstock/dhcrelay
+          # DOCKER_IMAGE=ghcr.io/jacobweinstock/dhcrelay
+          DOCKER_IMAGE=ghcr.io/${GITHUB_REPOSITORY}
           VERSION=latest
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
@@ -43,3 +44,4 @@ jobs:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,8 +36,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ jobs:
         id: prep
         run: |
           # DOCKER_IMAGE=ghcr.io/jacobweinstock/dhcrelay
-          DOCKER_IMAGE=ghcr.io/${GITHUB_REPOSITORY}
+          DOCKER_IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}
           VERSION=latest
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}


### PR DESCRIPTION
To add support for running Tinkerbell on arm64 platforms like the Raspberry Pi this adds the additional build argument `platforms` for the `buildx` command.

Additionally this replaces some hardcoded values with native GitHub actions variables.